### PR TITLE
Fix module name and static file path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module main.go
+module godev
 
 go 1.23.0

--- a/main.go
+++ b/main.go
@@ -38,7 +38,8 @@ func main() {
 		`)
 	})
 
-	fs := http.FileServer(http.Dir("static/"))
+	// serve files from the public directory
+	fs := http.FileServer(http.Dir("public/"))
 	http.Handle("/static/", http.StripPrefix("/static/", fs))
 
 	fmt.Println("Started server on http://localhost:8080")


### PR DESCRIPTION
## Summary
- correct module name so `go build` does not overwrite `main.go`
- serve static files from the `public` directory

## Testing
- `go vet ./...`
- `go build`


------
https://chatgpt.com/codex/tasks/task_e_68424d1d7bc48330bc49f7e70276fe0b